### PR TITLE
docs: create static storybook deploy script + env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log*
 # Build directory
 .cache
 dist/
+.out
 
 # Dependency directories
 node_modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
     "clean": "rm -rf dist/",
     "storybook": "start-storybook",
-    "storybook:build": "build-storybook -s ./storybook-out",
+    "storybook:build": "build-storybook -c .storybook -o .out",
     "test": "test"
   },
   "author": "David Sally <davidcsally@gmail.com>",


### PR DESCRIPTION
This adds the static Storybook deploy script, so that the public
storybook can be deployed to Vercel.